### PR TITLE
RabbitMQ: Fix permissions & update config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM rabbitmq:3.9.18-management
 COPY rabbitmq.conf /etc/rabbitmq/
 
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq.conf
+
+COPY docker-entrypoint.sh /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -1,9 +1,29 @@
 # RabbitMQ on Render
 
-This is a template repo for running a RabbitMQ instance as a **web service** on Render.
+This is a template repo for running a RabbitMQ instance as a **web service** on
+Render.
 
-It uses the [official Dockerfile](https://hub.docker.com/_/rabbitmq) and backs RabbitMQ with a [Render disk](https://render.com/docs/disks), making it resilient to data loss in the case of restarts or deploys.
+It uses the [official Dockerfile](https://hub.docker.com/_/rabbitmq) and backs
+RabbitMQ with a [Render disk](https://render.com/docs/disks), making it 
+resilient to data loss in the case of restarts or deploys.
 
 ### Deployment
 
 See https://render.com/docs/deploy-rabbitmq.
+
+### Permissions fixes
+
+When upgrading from 3.7.17 to 3.9.18, the Docker image's original entrypoint
+script consistently fails due to permissions issues - in particular, the
+`/var/lib/rabbitmq/.erlang.cookie` file cannot be opened because it is owned
+by group 1000 instead of group `rabbitmq (gid: 999)`.
+
+In order to resolve this issue, we modify `docker-entrypoint.sh` so that the
+erlang cookie file is explicitly owned by `rabbitmq:rabbitmq`. The modified
+script is created by copying the entrypoint script out of the docker container
+and manually modifying it. The Dockerfile for the image we deploy on Render 
+then instructs Docker replace the entrypoint script with our modified one.
+
+If RabbitMQ versions are updated in the future, make sure to remember to look
+at the entrypoint script - we may need to upgrade it (though hopefully we won't
+need a modified entrypoint script at all!).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# allow the container to be started with `--user`
+if [[ "$1" == rabbitmq* ]] && [ "$(id -u)" = '0' ]; then
+	if [ "$1" = 'rabbitmq-server' ]; then
+		find /var/lib/rabbitmq \! -user rabbitmq -exec chown rabbitmq '{}' +
+	fi
+
+	exec gosu rabbitmq "$BASH_SOURCE" "$@"
+fi
+
+deprecatedEnvVars=(
+	RABBITMQ_DEFAULT_PASS_FILE
+	RABBITMQ_DEFAULT_USER_FILE
+	RABBITMQ_MANAGEMENT_SSL_CACERTFILE
+	RABBITMQ_MANAGEMENT_SSL_CERTFILE
+	RABBITMQ_MANAGEMENT_SSL_DEPTH
+	RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT
+	RABBITMQ_MANAGEMENT_SSL_KEYFILE
+	RABBITMQ_MANAGEMENT_SSL_VERIFY
+	RABBITMQ_SSL_CACERTFILE
+	RABBITMQ_SSL_CERTFILE
+	RABBITMQ_SSL_DEPTH
+	RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT
+	RABBITMQ_SSL_KEYFILE
+	RABBITMQ_SSL_VERIFY
+	RABBITMQ_VM_MEMORY_HIGH_WATERMARK
+)
+hasOldEnv=
+for old in "${deprecatedEnvVars[@]}"; do
+	if [ -n "${!old:-}" ]; then
+		echo >&2 "error: $old is set but deprecated"
+		hasOldEnv=1
+	fi
+done
+if [ -n "$hasOldEnv" ]; then
+	echo >&2 'error: deprecated environment variables detected'
+	echo >&2
+	echo >&2 'Please use a configuration file instead; visit https://www.rabbitmq.com/configure.html to learn more'
+	echo >&2
+	exit 1
+fi
+
+# if long and short hostnames are not the same, use long hostnames
+if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ]; then
+	: "${RABBITMQ_USE_LONGNAME:=true}"
+fi
+
+### MODIFIED HERE ###
+ls -lah /var/lib/rabbitmq/.erlang.cookie >&2
+chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie
+chmod 600 /var/lib/rabbitmq/.erlang.cookie
+ls -lah /var/lib/rabbitmq/.erlang.cookie >&2
+### MODIFIED END ###
+
+exec "$@"

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,4 +1,2 @@
 loopback_users.guest = false
 listeners.tcp.default = 5672
-management.listener.port = 15672
-management.listener.ssl = false


### PR DESCRIPTION
In order to successfully deploy 3.9.x, we need to adjust the permissions of some files & remove some deprecated config params.

This PR adds (& documents) a hack to fix the permission issues.