### PR TITLE
Metrics: Expose metrics port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM rabbitmq:3.9.18-management
 
+# Upload our configuration file
 COPY rabbitmq.conf /etc/rabbitmq/
-
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq.conf
 
+# Upload modified entrypoint file
 COPY docker-entrypoint.sh /usr/local/bin
+
+# Expose 15692 (for metrics)
+EXPOSE 15692

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,10 +48,13 @@ if [ -z "${RABBITMQ_USE_LONGNAME:-}" ] && [ "$(hostname)" != "$(hostname -s)" ];
 fi
 
 ### MODIFIED HERE ###
-ls -lah /var/lib/rabbitmq/.erlang.cookie >&2
-chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie
-chmod 600 /var/lib/rabbitmq/.erlang.cookie
-ls -lah /var/lib/rabbitmq/.erlang.cookie >&2
+COOKIE_FILE=/var/lib/rabbitmq/.erlang.cookie
+if [ -f "$COOKIE_FILE" ]; then
+    ls -lah $COOKIE_FILE >&2
+    chown rabbitmq:rabbitmq $COOKIE_FILE
+    chmod 600 $COOKIE_FILE
+    ls -lah $COOKIE_FILE >&2
+fi
 ### MODIFIED END ###
 
 exec "$@"

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,2 +1,4 @@
 loopback_users.guest = false
 listeners.tcp.default = 5672
+prometheus.tcp.port = 15692
+prometheus.tcp.ip = 0.0.0.0


### PR DESCRIPTION
The docker image this rabbitmq deployment is based upon
starts up the Prometheus plugin by default, but we need to
expose the metrics port. That is by default 15692; we put it
explicitly in the config just to make it even clearer.